### PR TITLE
Fix bug caused by not providing labels

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,8 @@
 		{
 			"name": "Flutter",
 			"request": "launch",
-			"type": "dart"
+			"type": "dart",
+			"cwd": "./example"
 		}
 	]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.5] - 2020-01-25
+
+- Fix bug causing chart not to fail when labels not provided
+
 ## [0.1.4] - 2019-10-09
 
 - Add support for chart perimeter labels.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -396,7 +396,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.4"
+    version: "0.1.5"
   stack_trace:
     dependency: transitive
     description:

--- a/lib/spider_chart.dart
+++ b/lib/spider_chart.dart
@@ -90,7 +90,7 @@ class SpiderChartPainter extends CustomPainter {
       outerPoints.add(Offset(x, y) + center);
     }
 
-    if (this.labels.length != null) {
+    if (this.labels != null) {
       paintLabels(canvas, center, outerPoints, this.labels);
     }
     paintGraphOutline(canvas, center, outerPoints);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spider_chart
 description: Spider Chart is a simple spider/radar charting library for Flutter
-version: 0.1.4
+version: 0.1.5
 author: cnsumner <1318452-cnsumner@users.noreply.gitlab.com>
 homepage: https://github.com/cnsumner/flutter-spider-chart
 


### PR DESCRIPTION
When not providing the optional labels array, the chart would not draw

Also added launch config to allow launching example app from parent dir

Resolves: #4